### PR TITLE
In README change json -> jsonc for better highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The default behaviour of the plugin is to take over the standard key binding to 
 If you wish to use another key binding you can append the following to
 [keybindings.json](https://code.visualstudio.com/docs/getstarted/keybindings#_advanced-customization):
 
-```json
+```jsonc
   {
     "key": "cmd+o", // Revert the binding back to the editor default
     "command": "-quickOpener.show"
@@ -60,7 +60,7 @@ If you wish to use another key binding you can append the following to
 
 Example of how to define custom key bindings:
 
-```json
+```jsonc
   {
     "when": "inQuickOpener", // limit binding to when plugin is visible
     "command": "quickOpener.triggerItemAction",


### PR DESCRIPTION
Use `jsonc` for GitHub markdown for better code highlighting in README

## Before
<img width="1014" alt="image" src="https://github.com/mogelbrod/quick-opener/assets/107841/668cdd4e-d0e6-4990-a516-8a12de5b7eea">

## After
<img width="1083" alt="image" src="https://github.com/mogelbrod/quick-opener/assets/107841/a230d742-3ba1-441f-b3c7-973f1198fb11">
