### PR TITLE
open new or changed files since last commit (v0.9.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1429,7 +1429,6 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -2979,7 +2978,6 @@
       "integrity": "sha512-NNu0sjyNxpoiW3YuVFfNz7mxSQ+S4X2G28uqg2s+CzoqoQjLPsWSbsFFyztIAqt2vb8kfEAsJNepMGPTxFDx3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -7113,7 +7111,6 @@
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -9708,7 +9705,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11248,7 +11244,6 @@
       "integrity": "sha512-6qGjWccl5yoyugHt3jTgztJ9Y0JVzyH8/Voc/D8PlLat9pwxQYXz7W1Dpnq5h0/G5GCYGUaDSlYcyk3AMh5A6g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -13076,7 +13071,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13266,7 +13260,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13452,7 +13445,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -13546,7 +13538,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "quickopener",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "quickopener",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "2.3.10",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "publisher": "mogelbrod",
   "author": "Victor Hallberg <victor@hallberg.cc>",
   "license": "MIT",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "engines": {
     "vscode": "^1.108.0",
     "node": ">=18.0.0"
@@ -129,6 +129,11 @@
       {
         "command": "quickOpener.showChangedFiles",
         "title": "Quick Opener: Open Changed File"
+      },
+      {
+        "command": "quickOpener.refreshChangedFiles",
+        "title": "Refresh",
+        "icon": "$(refresh)"
       }
     ],
     "keybindings": [
@@ -182,14 +187,36 @@
         "args": "toggleMessage",
         "key": "ctrl+m",
         "mac": "cmd+m"
+      },
+      {
+        "command": "quickOpener.showChangedFiles",
+        "key": "ctrl+alt+p"
       }
-    ]
+    ],
+    "views": {
+      "scm": [
+        {
+          "id": "quickOpener.changedFilesView",
+          "name": "New or Changed since Last Commit",
+          "icon": "icon.png"
+        }
+      ]
+    },
+    "menus": {
+      "view/title": [
+        {
+          "command": "quickOpener.refreshChangedFiles",
+          "when": "view == quickOpener.changedFilesView",
+          "group": "navigation"
+        }
+      ]
+    }
   },
   "scripts": {
-    "clean": "rimraf dist test/dist quickopener-*.vsix .vscode-test",
-    "build": "./esbuild.mjs",
-    "build:watch": "./esbuild.mjs --watch",
-    "package": "npm run clean && ./esbuild.mjs --minify",
+    "clean": "rimraf dist test/dist --glob quickopener-*.vsix .vscode-test",
+    "build": "node esbuild.mjs",
+    "build:watch": "node esbuild.mjs --watch",
+    "package": "npm run clean && node esbuild.mjs --minify",
     "vscode:prepublish": "npm run package",
     "check": "concurrently --raw 'tsc' 'tsc -p ./test' 'biome check'",
     "fix": "biome check --write",

--- a/package.json
+++ b/package.json
@@ -125,6 +125,10 @@
       {
         "command": "quickOpener.showRevisionPicker",
         "title": "Quick Opener: Open by Revision"
+      },
+      {
+        "command": "quickOpener.showChangedFiles",
+        "title": "Quick Opener: Open Changed File"
       }
     ],
     "keybindings": [

--- a/src/changed-files-opener.ts
+++ b/src/changed-files-opener.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode'
 import { type FilePickItem, getButtonAction, type Opener } from './opener'
 import { ACTIONS as QUICK_OPENER_ACTIONS } from './quick-opener'
-import { getGitAPI, getRepository, listChangedFiles } from './utils'
+import { getChangedFiles, getGitAPI, getRecentFiles, getWorkspaceRepository, log } from './utils'
 
 /** Human-readable labels for git porcelain status codes. */
 const STATUS_DESCRIPTIONS: Record<string, string> = {
@@ -78,8 +78,9 @@ export class ChangedFilesOpener implements Opener {
   async updateItems(): Promise<void> {
     try {
       const api = await getGitAPI()
-      const repo = getRepository(api)
-      const files = await listChangedFiles(api.git.path, repo.rootUri.fsPath)
+      const repo = getWorkspaceRepository(api)
+      log(`ChangedFilesOpener.updateItems: repo=${repo.rootUri.fsPath}`)
+      const files = getChangedFiles(repo)
 
       if (files.length === 0) {
         this.qp.items = [
@@ -91,20 +92,27 @@ export class ChangedFilesOpener implements Opener {
           },
         ]
       } else {
-        this.qp.items = files.map(f => {
-          const absPath = vscode.Uri.joinPath(repo.rootUri, f.path).fsPath
-          const isUntracked = f.statusCode === '?'
-          return {
-            label: f.path,
-            description: STATUS_DESCRIPTIONS[f.statusCode] ?? f.statusCode,
-            path: absPath,
-            iconPath: this.icons ? vscode.ThemeIcon.File : undefined,
-            resourceUri: vscode.Uri.file(absPath),
-            buttons: isUntracked
-              ? [ACTIONS.openSplit]
-              : [ACTIONS.openDiff, ACTIONS.openSplit],
-          }
-        })
+        const recentRank = new Map(getRecentFiles().map((p, i) => [p, i]))
+        this.qp.items = [...files]
+          .sort((a, b) => {
+            const aAbs = vscode.Uri.joinPath(repo.rootUri, a.path).fsPath
+            const bAbs = vscode.Uri.joinPath(repo.rootUri, b.path).fsPath
+            return (recentRank.get(aAbs) ?? Infinity) - (recentRank.get(bAbs) ?? Infinity)
+          })
+          .map(f => {
+            const absPath = vscode.Uri.joinPath(repo.rootUri, f.path).fsPath
+            const isUntracked = f.statusCode === '?'
+            return {
+              label: f.path,
+              description: STATUS_DESCRIPTIONS[f.statusCode] ?? f.statusCode,
+              path: absPath,
+              iconPath: this.icons ? vscode.ThemeIcon.File : undefined,
+              resourceUri: vscode.Uri.file(absPath),
+              buttons: isUntracked
+                ? [ACTIONS.openSplit]
+                : [ACTIONS.openDiff, ACTIONS.openSplit],
+            }
+          })
       }
     } catch (err: any) {
       this.qp.items = [

--- a/src/changed-files-opener.ts
+++ b/src/changed-files-opener.ts
@@ -1,0 +1,159 @@
+import * as vscode from 'vscode'
+import { type FilePickItem, getButtonAction, type Opener } from './opener'
+import { ACTIONS as QUICK_OPENER_ACTIONS } from './quick-opener'
+import { getGitAPI, getRepository, listChangedFiles } from './utils'
+
+/** Human-readable labels for git porcelain status codes. */
+const STATUS_DESCRIPTIONS: Record<string, string> = {
+  M: 'Modified',
+  A: 'Added',
+  D: 'Deleted',
+  R: 'Renamed',
+  C: 'Copied',
+  U: 'Unmerged',
+  '?': 'Untracked',
+  T: 'Type changed',
+}
+
+/** Actions available for the changed files picker */
+export const ACTIONS = {
+  openDiff: {
+    iconPath: new vscode.ThemeIcon('compare-changes'),
+    tooltip: 'Diff against HEAD',
+  },
+  openSplit: QUICK_OPENER_ACTIONS.openSplit,
+} as const satisfies Record<string, vscode.QuickInputButton>
+
+/** String union of all valid {@link ACTIONS} keys for {@link ChangedFilesOpener}. */
+export type ActionId = keyof typeof ACTIONS
+/** Union type of all available action button objects for {@link ChangedFilesOpener}. */
+export type Action = (typeof ACTIONS)[ActionId]
+
+/**
+ * Quick picker listing all files modified, added, or untracked since the last commit.
+ * - Default accept: open the selected file in the editor.
+ * - Item button 1 (openDiff): diff the file against HEAD (hidden for untracked files).
+ * - Item button 2 (openSplit): open the file in a split editor.
+ */
+export class ChangedFilesOpener implements Opener {
+  readonly qp: vscode.QuickPick<FilePickItem>
+
+  private icons: boolean
+  private onDispose?: () => void
+
+  constructor(options: { icons?: boolean; onDispose?: () => void } = {}) {
+    this.icons = options.icons ?? true
+    this.onDispose = options.onDispose
+
+    this.qp = vscode.window.createQuickPick<FilePickItem>()
+    this.qp.title = 'Open Changed File (since last commit)'
+    this.qp.placeholder = 'Select a changed file to open…'
+    this.qp.busy = true
+
+    this.qp.onDidHide(() => this.dispose())
+    this.qp.onDidAccept(() => {
+      const item = this.qp.selectedItems[0]
+      if (!item?.isError && item?.path) {
+        this.openFile(item.path)
+      }
+      this.dispose()
+    })
+    this.qp.onDidTriggerItemButton((e: vscode.QuickPickItemButtonEvent<FilePickItem>) =>
+      this.triggerItemAction(e.button as Action, e.item),
+    )
+  }
+
+  /** Show the quick picker and start loading changed files. */
+  show(): void {
+    this.qp.show()
+    this.updateItems()
+  }
+
+  /** Hide/discard the quick picker. */
+  dispose(): void {
+    this.onDispose?.()
+    this.qp.dispose()
+  }
+
+  async updateItems(): Promise<void> {
+    try {
+      const api = await getGitAPI()
+      const repo = getRepository(api)
+      const files = await listChangedFiles(api.git.path, repo.rootUri.fsPath)
+
+      if (files.length === 0) {
+        this.qp.items = [
+          {
+            label: 'No changed files',
+            detail: 'No modified or new files since last commit.',
+            iconPath: this.icons ? new vscode.ThemeIcon('info') : undefined,
+            isError: true,
+          },
+        ]
+      } else {
+        this.qp.items = files.map(f => {
+          const absPath = vscode.Uri.joinPath(repo.rootUri, f.path).fsPath
+          const isUntracked = f.statusCode === '?'
+          return {
+            label: f.path,
+            description: STATUS_DESCRIPTIONS[f.statusCode] ?? f.statusCode,
+            path: absPath,
+            iconPath: this.icons ? vscode.ThemeIcon.File : undefined,
+            resourceUri: vscode.Uri.file(absPath),
+            buttons: isUntracked
+              ? [ACTIONS.openSplit]
+              : [ACTIONS.openDiff, ACTIONS.openSplit],
+          }
+        })
+      }
+    } catch (err: any) {
+      this.qp.items = [
+        {
+          label: 'Error listing changed files',
+          detail: err.message,
+          iconPath: this.icons ? new vscode.ThemeIcon('alert') : undefined,
+          isError: true,
+        },
+      ]
+    } finally {
+      this.qp.busy = false
+    }
+  }
+
+  /** No title-level actions — required by the {@link Opener} interface. */
+  triggerAction(_actionOrOffset: number | ActionId | Action): void {}
+
+  /** Trigger an item button action for the given item. */
+  async triggerItemAction(
+    actionOrOffset: number | ActionId | Action,
+    item = this.qp.activeItems[0],
+  ): Promise<void> {
+    if (!item?.path || item.isError) return
+    const action = getButtonAction(actionOrOffset, item.buttons, ACTIONS)
+
+    switch (action) {
+      case ACTIONS.openDiff: {
+        const api = await getGitAPI()
+        const fileUri = vscode.Uri.file(item.path)
+        const headUri = api.toGitUri(fileUri, 'HEAD')
+        vscode.commands.executeCommand('vscode.diff', headUri, fileUri, `HEAD ↔ ${item.label}`)
+        this.dispose()
+        return
+      }
+      case ACTIONS.openSplit: {
+        this.openFile(item.path, vscode.ViewColumn.Beside)
+        this.dispose()
+        return
+      }
+    }
+  }
+
+  private openFile(
+    absPath: string,
+    viewColumn: vscode.ViewColumn = vscode.ViewColumn.Active,
+  ): void {
+    vscode.workspace
+      .openTextDocument(vscode.Uri.file(absPath))
+      .then((doc: vscode.TextDocument) => vscode.window.showTextDocument(doc, { viewColumn }))
+  }
+}

--- a/src/changed-files-view.ts
+++ b/src/changed-files-view.ts
@@ -1,0 +1,90 @@
+import * as path from 'path'
+import * as vscode from 'vscode'
+import { getChangedFiles, getGitAPI, getWorkspaceRepository, log } from './utils'
+
+const STATUS_LABELS: Record<string, string> = {
+  M: 'Modified',
+  A: 'Added',
+  D: 'Deleted',
+  R: 'Renamed',
+  C: 'Copied',
+  U: 'Unmerged',
+  '?': 'Untracked',
+  T: 'Type changed',
+}
+
+/** A single file entry in the "New or Changed since Last Commit" tree view. */
+export class ChangedFileItem extends vscode.TreeItem {
+  constructor(
+    public readonly filePath: string,
+    public readonly statusCode: string,
+    repoRoot: string,
+  ) {
+    const absUri = vscode.Uri.file(path.join(repoRoot, filePath))
+    super(absUri, vscode.TreeItemCollapsibleState.None)
+    this.label = filePath
+    this.description = STATUS_LABELS[statusCode] ?? statusCode
+    this.iconPath = vscode.ThemeIcon.File
+    this.resourceUri = absUri
+    this.contextValue = statusCode === '?' ? 'untracked' : 'changed'
+    this.command = {
+      command: 'vscode.open',
+      title: 'Open File',
+      arguments: [absUri],
+    }
+  }
+}
+
+/**
+ * Tree data provider for the "New or Changed since Last Commit" view in the
+ * Source Control sidebar. Auto-refreshes when the git repository state changes.
+ */
+export class ChangedFilesViewProvider
+  implements vscode.TreeDataProvider<ChangedFileItem>, vscode.Disposable
+{
+  private readonly _onDidChangeTreeData = new vscode.EventEmitter<void>()
+  readonly onDidChangeTreeData = this._onDidChangeTreeData.event
+
+  private _repoWatcher?: vscode.Disposable
+  private _watchedRepoRoot?: string
+
+  refresh(): void {
+    this._onDidChangeTreeData.fire()
+  }
+
+  getTreeItem(element: ChangedFileItem): vscode.TreeItem {
+    return element
+  }
+
+  async getChildren(): Promise<ChangedFileItem[]> {
+    try {
+      const api = await getGitAPI()
+      const repo = getWorkspaceRepository(api)
+
+      if (repo.rootUri.fsPath !== this._watchedRepoRoot) {
+        this._repoWatcher?.dispose()
+        this._watchedRepoRoot = repo.rootUri.fsPath
+        this._repoWatcher = repo.state.onDidChange(() => {
+          log(
+            `ChangedFilesView: repo.state changed — ` +
+              `index=${repo.state.indexChanges.length}` +
+              ` worktree=${repo.state.workingTreeChanges.length}` +
+              ` untracked=${repo.state.untrackedChanges?.length ?? 'n/a'}`,
+          )
+          this.refresh()
+        })
+      }
+
+      log(`ChangedFilesView.getChildren: repo=${repo.rootUri.fsPath}`)
+      const files = getChangedFiles(repo)
+      return files.map(f => new ChangedFileItem(f.path, f.statusCode, repo.rootUri.fsPath))
+    } catch {
+      return []
+    }
+  }
+
+  dispose(): void {
+    this._repoWatcher?.dispose()
+    this._onDidChangeTreeData.dispose()
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,13 +1,14 @@
 import * as path from 'path'
 import * as vscode from 'vscode'
 import { ChangedFilesOpener } from './changed-files-opener'
+import { ChangedFilesViewProvider } from './changed-files-view'
 import { type Opener, setOpenerContext } from './opener'
 import { PathScanner } from './path-scanner'
 import { sepRegex } from './path-utils'
 import { QuickOpener } from './quick-opener'
 import { RevisionFileOpener } from './revision-file-opener'
 import { RevisionOpener } from './revision-opener'
-import { openFileRevision, setGlobalState } from './utils'
+import { openFileRevision, setGlobalState, setOutputChannel, trackRecentFile } from './utils'
 import { variableExpansionFactory } from './variable-expansion'
 
 /** Currently visible instance of plugin */
@@ -18,6 +19,37 @@ export function activate(ctx: vscode.ExtensionContext) {
   // Initialize vscode context value
   setOpenerContext(false)
   setGlobalState(ctx)
+
+  const outputChannel = vscode.window.createOutputChannel('Quick Opener')
+  ctx.subscriptions.push(outputChannel)
+  setOutputChannel(outputChannel)
+
+  // Track recently opened files to surface them first in the changed-files picker
+  ctx.subscriptions.push(
+    vscode.workspace.onDidOpenTextDocument(doc => {
+      if (doc.uri.scheme === 'file') trackRecentFile(doc.uri.fsPath)
+    }),
+  )
+
+  // Register "New or Changed since Last Commit" tree view in the Source Control sidebar
+  const changedFilesViewProvider = new ChangedFilesViewProvider()
+  ctx.subscriptions.push(changedFilesViewProvider)
+  ctx.subscriptions.push(
+    vscode.window.registerTreeDataProvider(
+      'quickOpener.changedFilesView',
+      changedFilesViewProvider,
+    ),
+  )
+  ctx.subscriptions.push(
+    vscode.commands.registerCommand('quickOpener.refreshChangedFiles', () => {
+      changedFilesViewProvider.refresh()
+    }),
+  )
+  ctx.subscriptions.push(
+    vscode.window.onDidChangeActiveTextEditor(() => {
+      changedFilesViewProvider.refresh()
+    }),
+  )
 
   const onDispose = () => {
     setOpenerContext(false)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,6 @@
 import * as path from 'path'
 import * as vscode from 'vscode'
+import { ChangedFilesOpener } from './changed-files-opener'
 import { type Opener, setOpenerContext } from './opener'
 import { PathScanner } from './path-scanner'
 import { sepRegex } from './path-utils'
@@ -162,6 +163,18 @@ export function activate(ctx: vscode.ExtensionContext) {
   ctx.subscriptions.push(
     vscode.commands.registerCommand('quickOpener.triggerTabCompletion', () => {
       if (instance instanceof QuickOpener) instance.triggerTabCompletion()
+    }),
+  )
+
+  ctx.subscriptions.push(
+    vscode.commands.registerCommand('quickOpener.showChangedFiles', () => {
+      const icons = vscode.workspace.getConfiguration('quickOpener').get<boolean>('icons')
+      instance = new ChangedFilesOpener({
+        icons,
+        onDispose,
+      })
+      instance.show()
+      setOpenerContext('changed-files')
     }),
   )
 }

--- a/src/opener.ts
+++ b/src/opener.ts
@@ -10,7 +10,7 @@ export interface Opener {
 }
 
 /** Value set on the `inQuickOpener` context key. `false` means no opener is visible. */
-export type OpenerContext = 'quick' | 'revision' | 'revision-file' | false
+export type OpenerContext = 'quick' | 'revision' | 'revision-file' | 'changed-files' | false
 
 /** Set the `inQuickOpener` context value. Pass `false` to clear it. */
 export function setOpenerContext(value: OpenerContext): void {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -71,6 +71,42 @@ export async function openFileRevision(
   await vscode.window.showTextDocument(doc, { viewColumn })
 }
 
+/** List all files changed since the last commit using `git status --porcelain`. */
+export async function listChangedFiles(
+  gitPath: string,
+  repoRoot: string,
+): Promise<Array<{ path: string; statusCode: string }>> {
+  const { stdout } = await execFile(
+    gitPath,
+    ['status', '--porcelain=v1', '-z', '--untracked-files=all'],
+    { cwd: repoRoot },
+  ).catch((error: Error & { stdout?: string; stderr?: string }) => {
+    const msg = error.stderr?.trim()
+    throw msg ? new Error(msg) : error
+  })
+
+  const results: Array<{ path: string; statusCode: string }> = []
+  const parts = stdout.split('\0')
+  let i = 0
+  while (i < parts.length) {
+    const entry = parts[i++]
+    if (!entry || entry.length < 3) continue
+    const x = entry[0] // index (staged) status
+    const y = entry[1] // worktree (unstaged) status
+    const filePath = entry.slice(3)
+    // For renames/copies the original path follows as the next NUL-delimited entry
+    if (x === 'R' || x === 'C' || y === 'R' || y === 'C') {
+      i++ // skip original path
+    }
+    // Prefer staged status over unstaged; skip ignored files
+    const statusCode = x !== ' ' && x !== '?' ? x : y
+    if (statusCode !== '!') {
+      results.push({ path: filePath, statusCode })
+    }
+  }
+  return results
+}
+
 /** List all files at a given git ref using `git ls-tree`. */
 export async function listFilesAtRef(
   gitPath: string,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,37 @@
 import { execFile as execFileCb } from 'node:child_process'
 import { promisify } from 'node:util'
+import * as nodePath from 'node:path'
 import * as vscode from 'vscode'
-import type { API, GitExtension, Ref, Repository } from './git'
+import type { API, Change, GitExtension, Ref, Repository } from './git'
+
+/** In-memory LRU list of recently opened file paths (most recent first, capped at 100). */
+const _recentFiles: string[] = []
+
+/** Record an opened file path, moving it to the front of the recent list. */
+export function trackRecentFile(fsPath: string): void {
+  const idx = _recentFiles.indexOf(fsPath)
+  if (idx !== -1) _recentFiles.splice(idx, 1)
+  _recentFiles.unshift(fsPath)
+  if (_recentFiles.length > 100) _recentFiles.pop()
+}
+
+/** Return the current in-memory list of recently opened paths, most recent first. */
+export function getRecentFiles(): readonly string[] {
+  return _recentFiles
+}
+
+/** Shared output channel for the Quick Opener extension. */
+let _outputChannel: vscode.OutputChannel | undefined
+
+/** Initialize the shared output channel. Called once from activate(). */
+export function setOutputChannel(channel: vscode.OutputChannel): void {
+  _outputChannel = channel
+}
+
+/** Write a message to the Quick Opener output channel. */
+export function log(message: string): void {
+  _outputChannel?.appendLine(`[${new Date().toISOString()}] ${message}`)
+}
 
 /** Reference to extension globalState object, set by {@link setGlobalState}. */
 let _globalState: vscode.Memento | undefined
@@ -55,6 +85,69 @@ export function getRepository(api: API): Repository {
   return result
 }
 
+/**
+ * Get the most relevant repository for the current workspace context.
+ *
+ * Strategy (in order):
+ * 1. The repo that owns the currently active editor file (most specific).
+ * 2. A repo whose rootUri is an ancestor of the first workspace folder.
+ * 3. The shallowest repo rooted inside the first workspace folder
+ *    (prevents a deeply-nested submodule from winning over the project root).
+ * 4. The shallowest repo across all registered repositories.
+ */
+export function getWorkspaceRepository(api: API): Repository {
+  // Step 1: active editor file — most precise signal.
+  // Handles both plain file:// editors and git:// diff views (where the actual
+  // file path is encoded as a JSON "path" field in the URI query string).
+  const activeUri = vscode.window.activeTextEditor?.document.uri
+  if (activeUri) {
+    let lookupUri: vscode.Uri | undefined
+    if (activeUri.scheme === 'file') {
+      lookupUri = activeUri
+    } else if (activeUri.scheme === 'git') {
+      try {
+        const params = JSON.parse(decodeURIComponent(activeUri.query)) as { path?: string }
+        if (params.path) lookupUri = vscode.Uri.file(params.path)
+      } catch {
+        // malformed query — skip
+      }
+    }
+    if (lookupUri) {
+      const active = api.getRepository(lookupUri)
+      if (active) return active
+    }
+  }
+
+  const workspaceFolders = vscode.workspace.workspaceFolders
+  if (workspaceFolders) {
+    for (const folder of workspaceFolders) {
+      // Step 2: repo whose root is at or above the workspace folder
+      const ancestor = api.getRepository(folder.uri)
+      if (ancestor) return ancestor
+
+      // Step 3: repos rooted inside this workspace folder — pick shallowest
+      const folderFsPath = folder.uri.fsPath
+      const inside = api.repositories
+        .filter(r => {
+          const rp = r.rootUri.fsPath
+          return rp === folderFsPath || rp.startsWith(folderFsPath + nodePath.sep)
+        })
+        .sort((a, b) => a.rootUri.fsPath.length - b.rootUri.fsPath.length)
+      if (inside.length > 0) return inside[0]
+    }
+  }
+
+  // Step 4: last resort — shallowest repo overall (avoids submodules first)
+  const sorted = [...api.repositories].sort(
+    (a, b) => a.rootUri.fsPath.length - b.rootUri.fsPath.length,
+  )
+  const result = sorted[0] ?? null
+  if (!result) {
+    throw new Error('Quick Opener: No git repository found in the current workspace')
+  }
+  return result
+}
+
 const execFile = promisify(execFileCb)
 
 /** Open specified file at a given git revision */
@@ -71,39 +164,68 @@ export async function openFileRevision(
   await vscode.window.showTextDocument(doc, { viewColumn })
 }
 
-/** List all files changed since the last commit using `git status --porcelain`. */
-export async function listChangedFiles(
-  gitPath: string,
-  repoRoot: string,
-): Promise<Array<{ path: string; statusCode: string }>> {
-  const { stdout } = await execFile(
-    gitPath,
-    ['status', '--porcelain=v1', '-z', '--untracked-files=all'],
-    { cwd: repoRoot },
-  ).catch((error: Error & { stdout?: string; stderr?: string }) => {
-    const msg = error.stderr?.trim()
-    throw msg ? new Error(msg) : error
-  })
+/** Map of VS Code git Status numeric values to single-letter codes.
+ * Values match the const enum order in git.d.ts (INDEX_MODIFIED=0, …). */
+const GIT_STATUS_TO_CODE: Record<number, string | undefined> = {
+  0: 'M', // INDEX_MODIFIED
+  1: 'A', // INDEX_ADDED
+  2: 'D', // INDEX_DELETED
+  3: 'R', // INDEX_RENAMED
+  4: 'C', // INDEX_COPIED
+  5: 'M', // MODIFIED
+  6: 'D', // DELETED
+  7: '?', // UNTRACKED
+  // 8 = IGNORED — excluded
+  9: 'A', // INTENT_TO_ADD
+  11: 'T', // TYPE_CHANGED
+  12: 'U', // ADDED_BY_US
+  13: 'U', // ADDED_BY_THEM
+  14: 'U', // DELETED_BY_US
+  15: 'U', // DELETED_BY_THEM
+  16: 'U', // BOTH_ADDED
+  17: 'U', // BOTH_DELETED
+  18: 'U', // BOTH_MODIFIED
+}
 
+/**
+ * Get all changed or new files since the last commit using the VS Code git
+ * extension's already-computed repository state (same source as the built-in
+ * Source Control view). Returns a deduplicated list with staged changes first,
+ * then working-tree changes, then untracked files.
+ */
+export function getChangedFiles(
+  repo: Repository,
+): Array<{ path: string; statusCode: string }> {
+  const repoRoot = repo.rootUri.fsPath
+  const seen = new Set<string>()
   const results: Array<{ path: string; statusCode: string }> = []
-  const parts = stdout.split('\0')
-  let i = 0
-  while (i < parts.length) {
-    const entry = parts[i++]
-    if (!entry || entry.length < 3) continue
-    const x = entry[0] // index (staged) status
-    const y = entry[1] // worktree (unstaged) status
-    const filePath = entry.slice(3)
-    // For renames/copies the original path follows as the next NUL-delimited entry
-    if (x === 'R' || x === 'C' || y === 'R' || y === 'C') {
-      i++ // skip original path
-    }
-    // Prefer staged status over unstaged; skip ignored files
-    const statusCode = x !== ' ' && x !== '?' ? x : y
-    if (statusCode !== '!') {
-      results.push({ path: filePath, statusCode })
-    }
+
+  log(
+    `getChangedFiles: index=${repo.state.indexChanges.length}` +
+      ` worktree=${repo.state.workingTreeChanges.length}` +
+      ` untracked=${repo.state.untrackedChanges?.length ?? 'n/a'}` +
+      ` merge=${repo.state.mergeChanges.length}`,
+  )
+
+  const addChange = (change: Change): void => {
+    const fsPath = change.uri.fsPath
+    if (seen.has(fsPath)) return
+    seen.add(fsPath)
+    const statusCode = GIT_STATUS_TO_CODE[change.status]
+    if (!statusCode) return
+    // Make the path relative to the repo root
+    const relative = fsPath.startsWith(repoRoot)
+      ? fsPath.slice(repoRoot.length).replace(/^[\\/]/, '')
+      : fsPath
+    results.push({ path: relative, statusCode })
   }
+
+  for (const change of repo.state.indexChanges) addChange(change)
+  for (const change of repo.state.workingTreeChanges) addChange(change)
+  for (const change of repo.state.untrackedChanges ?? []) addChange(change)
+  for (const change of repo.state.mergeChanges) addChange(change)
+
+  log(`getChangedFiles: returning ${results.length} file(s)`)
   return results
 }
 


### PR DESCRIPTION
# Pull request: open new or changed files since last commit (v0.9.0)

Closes: [#12 issue v0.9.0 since_last_commit](https://github.com/mogelbrod/quick-opener/issues/12)

Reference: <https://stackoverflow.com/questions/79898327/quickly-open-only-modified-or-new-files-in-vs-code-since-last-commit>

## Summary

Two new features are added to [quick-opener](https://github.com/mogelbrod/quick-opener), with full support for **multi-root workspaces** containing nested or sibling git repositories:

1. **`Ctrl+Alt+P` — "Open Changed File" quick picker** — a keyboard-driven panel listing all files that are new or modified since the last commit in the repository that owns the currently active file.
2. **"New or Changed since Last Commit" view in Source Control** — a persistent tree view in the Source Control sidebar showing the same list, with automatic refresh whenever the repository state changes or the active editor switches to a file in a different repository.

<img width="1571" height="748" alt="2026-04-02_201424" src="https://github.com/user-attachments/assets/5ff9c580-b197-4daf-8224-63b7eaf5f768" />


## Changes

### Feature 1 — "Open Changed File" quick picker (`Ctrl+Alt+P`)

**`src/changed-files-opener.ts`** (new)  
New `ChangedFilesOpener` class implementing the `Opener` interface. Shows a `vscode.QuickPick` panel populated from `getChangedFiles()`. Each item displays:

- the repo-relative file path as label
- a human-readable status (`Modified` / `Added` / `Untracked` / …) as description
- item button: diff against HEAD (hidden for untracked files, since there is no HEAD version)
- item button: open in a split editor

Items are sorted so recently opened files appear first (tracked via `onDidOpenTextDocument` → `trackRecentFile()`).

**`src/opener.ts`**  
Added `'changed-files'` to the `OpenerContext` union type so the new opener integrates with the existing context-key system.

**`src/extension.ts`** (excerpt)  
Registered `quickOpener.showChangedFiles` command: instantiates `ChangedFilesOpener`, calls `.show()`, and sets the opener context to `'changed-files'`.

**`package.json`** (excerpt)

- New command declaration: `quickOpener.showChangedFiles` — "Quick Opener: Open Changed File"
- New keybinding: `Ctrl+Alt+P` → `quickOpener.showChangedFiles`

---

### Feature 2 — "New or Changed since Last Commit" Source Control sidebar view

**`src/changed-files-view.ts`** (new)  
New `ChangedFilesViewProvider` (implements `vscode.TreeDataProvider`) and `ChangedFileItem` (extends `vscode.TreeItem`). Each tree item opens the file on click via the `vscode.open` command. The provider:

- calls `getChangedFiles()` on first render
- tracks `_watchedRepoRoot`: each time `getChildren()` is called, if the repo resolved by `getWorkspaceRepository()` differs from the previously watched one, it disposes the old `repo.state.onDidChange` subscription and creates a new one for the current repo
- exposes `refresh()` wired to the `quickOpener.refreshChangedFiles` command

**`src/extension.ts`** (excerpt)  
Registers `ChangedFilesViewProvider` via `vscode.window.registerTreeDataProvider`, registers `quickOpener.refreshChangedFiles`, and subscribes to `vscode.window.onDidChangeActiveTextEditor` — calling `changedFilesViewProvider.refresh()` on every editor switch so the view re-resolves the repo from the new active file.

**`package.json`** (excerpt)

- New command: `quickOpener.refreshChangedFiles` — "Refresh" (icon `$(refresh)`)
- New view in the `scm` container: `quickOpener.changedFilesView` — "New or Changed since Last Commit"
- New `view/title` menu entry: refresh button shown when `view == quickOpener.changedFilesView`

---

### Shared infrastructure

**`src/utils.ts`**

- `trackRecentFile(fsPath)` / `getRecentFiles()` — in-memory LRU list (capped at 100) of recently opened file paths, most recent first. Powers the ordering in the quick picker.
- `setOutputChannel(channel)` / `log(message)` — shared output channel for diagnostics, visible under View → Output → "Quick Opener".
- `getWorkspaceRepository(api)` — 4-step strategy for multi-root and submodule workspaces:
  1. **Active editor** — resolves the repo from the currently focused file. Handles both `file://` editors and `git://` SCM diff views (the real path is decoded from the JSON `path` field in the URI query string).
  2. **Workspace folder ancestor** — iterates `vscode.workspace.workspaceFolders` and checks if any repo root is an ancestor of the folder URI.
  4. **Shallowest repo inside the workspace folder** — when step 2 yields nothing (e.g. the workspace folder is a child of the repo root), filters repos whose `rootUri` starts inside the folder and picks the one with the shortest path, avoiding deeply nested submodules.
  5. **Shallowest repo overall** — last resort, sorted by path length so submodules (long paths) lose to the project root.
- `getChangedFiles(repo)` — reads `repo.state.indexChanges`, `repo.state.workingTreeChanges`, `repo.state.untrackedChanges`, and `repo.state.mergeChanges` synchronously. Deduplicates by `fsPath` and maps VS Code's numeric `Status` enum values to single-letter codes (`M`, `A`, `D`, `R`, `C`, `U`, `?`, `T`). Returns `Array<{ path: string, statusCode: string }>` with repo-relative paths.

**`src/extension.ts`** (excerpt)  
Creates the "Quick Opener" `OutputChannel`, passes it to `setOutputChannel()`, and subscribes to `vscode.workspace.onDidOpenTextDocument` to call `trackRecentFile()` for every opened `file://` document.

---

### Build fix

**`package.json`** — build scripts changed from `./esbuild.mjs` to `node esbuild.mjs` (Windows `cmd` cannot execute `.mjs` files directly). The `clean` script gained `--glob` so `rimraf` v5 (pure ESM) accepts the `quickopener-*.vsix` glob pattern. Version bumped `0.8.0` → `0.9.0`.

## Key design decisions

| Decision | Reason |
| --- | --- |
| Use `repo.state` instead of `git status` subprocess | Avoids process spawning, works on Windows, stays in sync with the built-in SCM view |
| 4-step `getWorkspaceRepository()` (active editor first) | Active editor is the most precise signal in a multi-root workspace with submodules; workspace-folder and shallowest-path fallbacks handle the case where no file is open |
| Decode `git://` URI query path in step 1 | SCM diff views use `git:` scheme with the real path embedded as JSON in the query string; decoding it lets the active-editor check work even when comparing file revisions |
| `_watchedRepoRoot` tracking in the tree view | Allows the `repo.state.onDidChange` subscription to follow the current repo when the active editor switches to a file in a different repository |
| `onDidChangeActiveTextEditor` triggers view refresh | The SCM sidebar view re-runs `getChildren()`, which re-resolves the repo and re-subscribes to its state changes |
| In-memory LRU for recency, not persistent storage | Session-scoped recency is sufficient; avoids stale data across branches |
